### PR TITLE
Nitrous.io "Quickstart" Updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On Windows, the easiest way to set permanent environment variables (as of Window
 
 ## Nitrous Quickstart
 
-With [Nitrous.io](https://www.nitrous.io/) you can create a ready-made Brunch development environnment in just a few minutes at the click of a button.
+With [Nitrous.io](https://www.nitrous.io/) you can create a ready-made development environnment in just a few minutes at the click of a button.
 
 [Sign up](https://www.nitrous.io/app/#/signup) and [login](https://www.nitrous.io/app/#/login) to the Nitrous platform then click the button below to begin the Quickstart project creation process:
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@ On Windows, the easiest way to set permanent environment variables (as of Window
     setx TWILIO_AUTH_TOKEN XXXXXXXXX
     setx TWILIO_NUMBER +16518675309
 
-## Developing on Nitrous.IO
+## Nitrous Quickstart
 
-Start hacking on this app on [Nitrous.IO](https://www.nitrous.io/?utm_source=github.com&utm_campaign=twilio-starter-ruby&utm_medium=hackonnitrous) in seconds:
+With [Nitrous.io](https://www.nitrous.io/) you can create a ready-made Brunch development environnment in just a few minutes at the click of a button.
 
-[![Hack twilio/starter-ruby on
-Nitrous.IO](https://d3o0mnbgv6k92a.cloudfront.net/assets/hack-l-v1-3cc067e71372f6045e1949af9d96095b.png)](https://www.nitrous.io/hack_button?source=embed&runtime=rails&repo=twilio%2Fstarter-ruby&file_to_open=README.nitrous.md)
+[Sign up](https://www.nitrous.io/app/#/signup) and [login](https://www.nitrous.io/app/#/login) to the Nitrous platform then click the button below to begin the Quickstart project creation process:
+
+[![Nitrous Quickstart](https://nitrous-image-icons.s3.amazonaws.com/quickstart.svg)](https://www.nitrous.io/quickstart?repo=https://github.com/twilio/starter-ruby)
+
+For further detailed instructions on how to proceed, read through [this repository's Quickstart readme file](https://github.com/twilio/starter-ruby/blob/master/nitrous.readme.md).
 
 ## Running the application locally
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -34,12 +34,17 @@ To run the app on Nitrous:
 
 1 - Click the ""Run starter-ruby App"" option from the "Run" tab to start the application.
 
+![Nitrous Run Menu](http://i.imgur.com/MKvommW.png)
+
 2 - Then click the "Preview" tab and "Port 3000".
+
+![Nitrous Preview Menu](http://i.imgur.com/KQHm6qN.png)
 
 Alternatively instead of the above, run the following commands in the terminal:
 
 ```bash
 $ cd ~/workspace/starter-ruby
 $ ./script/server
+```
 
-Then go to the "Preview Menu" and click "Port 3000"
+Then go to the "Preview" tab and click "Port 3000"

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,22 +1,45 @@
-# Setup for Nitrous.IO
+# Nitrous Quickstart
 
-Before you can run this project, you will need to set three system environment variables.  These are:
+This `nitrous.readme.md` file contains instructions on how to use the Nitrous [Quickstart](https://www.nitrous.io/quickstarts/) feature with this project.
+
+Quickstarts allow you to create an out of the box development environment on Nitrous in just a few minutes; without having to perform the expected setup or configuration beforehand.
+
+## How to Use
+
+All that's required is a [Nitrous.io account](https://www.nitrous.io) and that your are signed in to this account with your web browser when you click the Quickstart trigger button below.
+
+Click the button to begin the process once signed in:
+
+[![Nitrous Quickstart](https://nitrous-image-icons.s3.amazonaws.com/quickstart.svg)](https://www.nitrous.io/quickstart?repo=https://github.com/twilio/starter-ruby)
+
+> The Quick Start setup process will take several minutes to complete.
+
+After the process completes you are redirected to your new development environnment on Nitrous.
+
+Before you can run this project, you will need to set three system environment variables. These are:
 
 * `TWILIO_ACCOUNT_SID` : Your Twilio "account SID" - it's like your username for the Twilio API.  This and the auth token (below) can be found [on your account dashboard](https://www.twilio.com/user/account).
 * `TWILIO_AUTH_TOKEN` : Your Twilio "auth token" - it's your password for the Twilio API.  This and the account SID (above) can be found [on your account dashboard](https://www.twilio.com/user/account).
 * `TWILIO_NUMBER` : A Twilio number that you own, that can be used for making calls and sending messages.  You can find a list of phone numbers you control (and buy another one, if necessary) [in the account portal](https://www.twilio.com/user/account/phone-numbers/incoming).
 
-Environment Variables can be set by opening a terminal window and typing the following three commands - replace all the characters after the `=` with values from your Twilio account:
+Environment Variables can be set in the terminal window by typing the following three commands - replace all the characters after the `=` with values from your Twilio account:
 
-    export TWILIO_ACCOUNT_SID=ACXXXXXXXXX
-    export TWILIO_AUTH_TOKEN=XXXXXXXXX
-    export TWILIO_NUMBER=+16518675309
+```bash
+$ export TWILIO_ACCOUNT_SID=ACXXXXXXXXX
+$ export TWILIO_AUTH_TOKEN=XXXXXXXXX
+$ export TWILIO_NUMBER=+16518675309
+```
 
-Run the following commands in the Terminal below:
+To run the app on Nitrous:
 
-1. `cd ~/workspace/starter-ruby`
-2. `bundle`
-3. `./script/server`
+1 - Click the ""Run starter-ruby App"" option from the "Run" tab to start the application.
 
-Go to the "Preview Menu" and click "Port 3000"
+2 - Then click the "Preview" tab and "Port 3000".
 
+Alternatively instead of the above, run the following commands in the terminal:
+
+```bash
+$ cd ~/workspace/starter-ruby
+$ ./script/server
+
+Then go to the "Preview Menu" and click "Port 3000"

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ~/code/starter-ruby
+bundle

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "ruby",
+  "ports": [3000],
+  "name": "starter-ruby",
+  "logo": "http://i.imgur.com/ZwtzAso.png",
+  "description": "https://github.com/twilio/starter-ruby",
+  "scripts": {
+    "Run starter-ruby App": "cd ~/code/starter-ruby && ./script/server",
+  }
+}

--- a/nitrous.json
+++ b/nitrous.json
@@ -5,6 +5,6 @@
   "logo": "http://i.imgur.com/ZwtzAso.png",
   "description": "https://github.com/twilio/starter-ruby",
   "scripts": {
-    "Run starter-ruby App": "cd ~/code/starter-ruby && ./script/server",
+    "Run starter-ruby App": "cd ~/code/starter-ruby && ./script/server"
   }
 }


### PR DESCRIPTION
[Nitrous.io](https://www.nitrous.io/) have recently updated the old "Hack Button" feature they have for GitHub repos. All the changes needed to remove the old button and add the new "Quickstart" one are provided here in this pull request. 

If this project is still being maintained could you please take a look and consider merging. 

Here’s some more links that might help explain:

[Blog Post Explaining Quickstarts](https://community.nitrous.io/posts/nitrous-quickstarts)
[Specifically How Quickstarts Work](https://community.nitrous.io/docs/nitrous-quickstarts)

Thanks. 